### PR TITLE
Avoid some type-related warnings

### DIFF
--- a/lib/zlibtop.cpp
+++ b/lib/zlibtop.cpp
@@ -11,7 +11,7 @@ ZLibBaseCompressor::ZLibBaseCompressor(int level, flush_parameter autoFlush,
                                        int windowBits) {
   int retval;
   finished_ = false;
-  autoFlush_ = autoFlush;
+  autoFlush_ = autoFlush != no_flush;
   strm_.zalloc = Z_NULL;
   strm_.zfree = Z_NULL;
   strm_.opaque = Z_NULL;
@@ -34,9 +34,9 @@ std::string ZLibBaseCompressor::baseCompress(const std::string& input) {
     throw std::exception();
   }
   for (uint32_t i = 0; i < input.length(); i += ZLIB_COMPLETE_CHUNK) {
-    int howManyLeft = input.length() - i;
-    bool isLastRound = (howManyLeft <= ZLIB_COMPLETE_CHUNK);
-    int howManyWanted = (howManyLeft > ZLIB_COMPLETE_CHUNK) ?
+    const uInt howManyLeft = static_cast<uInt>(input.length() - i);
+    const bool isLastRound = (howManyLeft <= ZLIB_COMPLETE_CHUNK);
+    const auto howManyWanted = (howManyLeft > ZLIB_COMPLETE_CHUNK) ?
                            ZLIB_COMPLETE_CHUNK : howManyLeft;
     memcpy(in_, input.data()+i, howManyWanted);
     strm_.avail_in = howManyWanted;
@@ -105,8 +105,8 @@ std::string ZLibBaseDecompressor::baseDecompress(const std::string& input) {
   int retval;
   std::string result;
   for (uint32_t i = 0; i < input.length(); i += ZLIB_COMPLETE_CHUNK) {
-    int howManyLeft = input.length() - i;
-    int howManyWanted = (howManyLeft > ZLIB_COMPLETE_CHUNK) ?
+    const auto howManyLeft = static_cast<uInt>(input.length() - i);
+    const auto howManyWanted = (howManyLeft > ZLIB_COMPLETE_CHUNK) ?
                            ZLIB_COMPLETE_CHUNK : howManyLeft;
     memcpy(in_, input.data()+i, howManyWanted);
     strm_.avail_in = howManyWanted;

--- a/lib/zlibtop.cpp
+++ b/lib/zlibtop.cpp
@@ -34,7 +34,7 @@ std::string ZLibBaseCompressor::baseCompress(const std::string& input) {
     throw std::exception();
   }
   for (uint32_t i = 0; i < input.length(); i += ZLIB_COMPLETE_CHUNK) {
-    const uInt howManyLeft = static_cast<uInt>(input.length() - i);
+    const auto howManyLeft = static_cast<uInt>(input.length() - i);
     const bool isLastRound = (howManyLeft <= ZLIB_COMPLETE_CHUNK);
     const auto howManyWanted = (howManyLeft > ZLIB_COMPLETE_CHUNK) ?
                            ZLIB_COMPLETE_CHUNK : howManyLeft;


### PR DESCRIPTION
I got some warnings about
* Implicit conversion of integer (enum) to bool
* Converting size_t to int

Then, some of the values can be const

If this must be compatible with pre-C++11 compilers, the `auto` could be easily changed into `uInt`.